### PR TITLE
Replace `map` with `outline-minor-mode-map` when defining keys

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -523,7 +523,13 @@ recover it by stripping off \"-map\" from KEYMAP name."
                          "Could not deduce mode name from keymap name")
                         (intern "dummy-sym"))
                       )) nil)
-                (original-func (key-binding ,key)))
+		;; Check for `<tab>'.  It translates to `TAB' which
+		;; will prevent `(key-binding ...)' from finding the
+		;; original binding.
+                (original-func (if (equal (kbd "<tab>") ,key)
+                                   (or (key-binding ,key)
+                                       (key-binding (kbd "TAB")))
+                                 (key-binding ,key)))
            (condition-case nil
                (call-interactively original-func)
              (error nil)))))))


### PR DESCRIPTION
Let binding is not needed when replacing all instances of `map` with `outline-minor-mode-map`.  Indentation adjusted for line length.  Fixes `Could not deduce mode name from keymap name` error [ #16 ]

Second commit adds test to fall back to `TAB` if `<tab>` has not been manually bound by user.  If `<tab>` is bound, use it.

Testing this way is more efficient than mapping to `TAB` directly, since `TAB` also influences <kbd>C-i</kbd>.
