### PR TITLE
Fix bug with electric-pair-mode

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -2295,8 +2295,11 @@ overwritten, and the table is not marked as requiring realignment."
             (setq outshine-self-insert-command-undo-counter
                   (1+ outshine-self-insert-command-undo-counter))))))))
 
-;; comply with `delete-selection-mode'
-(put 'outshine-self-insert-command 'delete-selection t)
+;; comply with `delete-selection-mode' and `electric-pair-mode'
+(put 'outshine-self-insert-command 'delete-selection
+     (lambda ()
+       (not (run-hook-with-args-until-success
+             'self-insert-uses-region-functions))))
 
 ;;;;; Other Commands
 


### PR DESCRIPTION
With both electric-pair-mode and delete-selection-mode active, typing an open parenthesis removes the selection (if any) before inserting the () pair, instead of placing the pair around the selection. This patch fixes that problem.

Compare commit 7fe99af6 of the org-mode repository.
