### PR TITLE
Declare dependency to `outorg`

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -3,6 +3,7 @@
 ;; Author: Thorsten Jolitz <tjolitz AT gmail DOT com>
 ;; Version: 2.0
 ;; URL: https://github.com/tj64/outshine
+;; Package-Requires: ((outorg "2.0"))
 
 ;;;; MetaData
 ;;   :PROPERTIES:


### PR DESCRIPTION
`outshine`'s dependency to `outorg` is correctly documented in the README file. However, end-users installing it via the emacs's package manager will typically not see it, leading to the situation described in issue #35.

Declaring the dependency in the package header will allow MELPA to add the dependency in the package it builds, which in turn will make `package.el` correctly install `outorg` before `outshine`, without the end users having to do anything special.
