### PR TITLE
Load cl for using case macro

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -255,6 +255,8 @@
 
 ;;; Requires
 
+(eval-when-compile
+  (require 'cl))
 (require 'outline)
 (require 'outorg)
 ;; necessary before Emacs 24.3


### PR DESCRIPTION
This is updated version #50. This patch fixes some byte-compile warnings.

```
In outshine-TeX-command-region-on-subtree:
outshine.el:2617:4:Warning: `4' is a malformed function
outshine.el:2617:4:Warning: `16' is a malformed function
outshine.el:2624:8:Warning: `t' called as a function

In outshine-time-stamp-inactive:
outshine.el:2888:29:Warning: reference to free variable
    `org-element--timestamp-regexp'

In outshine-time-stamp:
outshine.el:2966:29:Warning: reference to free variable
    `org-element--timestamp-regexp'

In end of data:
outshine.el:4329:1:Warning: the following functions are not known to be
    defined: case, t
```
