### PR TITLE
Add out-of-the-box compatibility with company idle completion

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -2351,6 +2351,9 @@ overwritten, and the table is not marked as requiring realignment."
        (not (run-hook-with-args-until-success
              'self-insert-uses-region-functions))))
 
+;; trigger company idle completion like namesake command
+(put 'outshine-self-insert-command 'company-begin t))
+
 ;;;;; Other Commands
 
 (defun outshine-narrow-to-subtree ()


### PR DESCRIPTION
Rather then rely on the workaround documented in issue #38, let `outshine` play nice with `company` idle highlight out of the box.

See #38.
See [`company-begin-commands`](https://github.com/company-mode/company-mode/blob/90ec4ceef924e0b9dd3fabe62e1441ceab770e61/company.el#L571-L572).