### PR TITLE
added one autoload cookie

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -1563,6 +1563,7 @@ function was called upon."
 
 ;;;;; Hook function
 
+;;;###autoload
 (defun outshine-hook-function ()
   "Add this function to outline-minor-mode-hook"
   (outshine-set-outline-regexp-base)


### PR DESCRIPTION
This allows outshine package to be autoloaded so that the user need not
manually add (require 'outshine). Using autoload is a generally good
idea. Also this change makes it easier to create a spacemacs layer for
outshine, outorg, and navi packages.