### PR TITLE
Don't clobber imenu-generic-expression

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -1580,9 +1580,12 @@ function was called upon."
     (and outshine-imenu-show-headlines-p
          (set (make-local-variable
                'outshine-imenu-preliminary-generic-expression)
-               `((nil ,(concat out-regexp "\\(.*$\\)") 1)))
-         (setq imenu-generic-expression
-               outshine-imenu-preliminary-generic-expression)))
+               `(("Outline" ,(concat out-regexp "\\(.*$\\)") 1)))
+	 (if imenu-generic-expression
+	     (add-to-list 'imenu-generic-expression
+                          (car outshine-imenu-preliminary-generic-expression))
+           (setq imenu-generic-expression
+                 outshine-imenu-preliminary-generic-expression))))
   (when outshine-startup-folded-p
     (condition-case error-data
         (outline-hide-sublevels 1)

--- a/outshine.el
+++ b/outshine.el
@@ -1580,7 +1580,7 @@ function was called upon."
     (and outshine-imenu-show-headlines-p
          (set (make-local-variable
                'outshine-imenu-preliminary-generic-expression)
-               `(("Outline" ,(concat out-regexp "\\(.*$\\)") 1)))
+               `((nil ,(concat out-regexp "\\(.*$\\)") 1)))
 	 (if imenu-generic-expression
 	     (add-to-list 'imenu-generic-expression
                           (car outshine-imenu-preliminary-generic-expression))


### PR DESCRIPTION
Fix outshine-hook-function so that it doesn't mess up imenu-generic-expression
See https://github.com/tj64/outshine/issues/41